### PR TITLE
change to home_url to make browser reload work in more local settings

### DIFF
--- a/public/themes/nanu/inc/Setup/Enqueue.php
+++ b/public/themes/nanu/inc/Setup/Enqueue.php
@@ -40,7 +40,7 @@ class Enqueue
 
 		// Activate browser-sync on development environment
 		if ( in_array( env( 'WP_ENV' ), [ 'local', 'development' ] ) ) :
-			wp_enqueue_script( '__bs_script__', get_site_url() . ':3000/browser-sync/browser-sync-client.js', array(), null, true );
+			wp_enqueue_script( '__bs_script__', home_url() . ':3000/browser-sync/browser-sync-client.js', array(), null, true );
 		endif;
 
 		// Extra


### PR DESCRIPTION
In some cases (as mine) "/wordpress/" may occur in the URL. This can arise when WordPress is installed in a directory other than public_html (or whatever web root your host uses). This can be useful if you're trying to achieve that end. If instead, you are trying to reliably access the URL of the home page of the site, be sure to use home_url().